### PR TITLE
Fixed to use amplify backend environment as branchName

### DIFF
--- a/resources/awscloudformation/cloudformation-templates/amplify-console-notification-cloudformation-template.json.ejs
+++ b/resources/awscloudformation/cloudformation-templates/amplify-console-notification-cloudformation-template.json.ejs
@@ -34,7 +34,7 @@
                             {"Ref": "appId"}
                         ],
                         "branchName": [
-                            "main"
+                            {"Ref": "env"}
                         ],
                         "jobStatus": [
                             "SUCCEED",


### PR DESCRIPTION
This fix does not cover all patterns.
For example, the branch name is different from the backend environment.
Support in that case will be provided separately from this fix.

fix #4 