### PR TITLE
nodejs10.x -> nodejs14.x in lambda-cloudformation-template

### DIFF
--- a/resources/triggers/slack/lambda-cloudformation-template.json.ejs
+++ b/resources/triggers/slack/lambda-cloudformation-template.json.ejs
@@ -61,7 +61,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs10.x",
+            "Runtime": "nodejs14.x",
             "Timeout": "25"
           }
         },


### PR DESCRIPTION
Due to the end of support for Node.js 10 in AWS Lambda on July 30, 2021, we have changed the Node.js version in the Lambda template to 14.

Issue
Update Node.js verison with the end of Node.js 10 support #10
----

Content
----
Modified lambda-cloudformation-template  from nodejs10.x to nodejs14.x